### PR TITLE
fix: Increase cron container size from S to M for database import

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -2,7 +2,7 @@
   "jobs": [
     {
       "command": "0 3 * * * sh /app/scripts/database-import.sh",
-      "size": "S"
+      "size": "M"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Increase cron container size from S (Small) to M (Medium) for the nightly database import job

## Problem
The nightly database import was failing silently because the Small container (256 MB RAM) couldn't handle the ~426 MB MySQL dump import. This caused Metabase data to become stale (3 days behind).

## Solution
Upgrade the cron container size to Medium to provide enough memory for the import process.

## Test plan
- [ ] Deploy to Scalingo
- [ ] Verify cron task shows size M: `scalingo --app askara-metabase cron-tasks`
- [ ] Wait for next nightly import at 3 AM
- [ ] Verify data freshness in Metabase